### PR TITLE
Fix code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/database/user.go
+++ b/database/user.go
@@ -7,7 +7,7 @@ import (
 
 func (m *MySQL) CreateUser(username string, password string) error {
 	// Log the action
-	log.Printf("Creating user %s with password %s", username, password)
+	log.Printf("Creating user %s", username)
 	// Construct the query using the escaped values
 	query := fmt.Sprintf("CREATE USER '%s'@'%%' IDENTIFIED BY '%s'", username, password)
 


### PR DESCRIPTION
Fixes [https://github.com/Advik-B/SQL-Sensi/security/code-scanning/1](https://github.com/Advik-B/SQL-Sensi/security/code-scanning/1)

To fix the problem, we should avoid logging the password in clear text. Instead, we can log the username and omit the password from the log message. This way, we still have useful information for debugging purposes without exposing sensitive data.

- Remove the password from the log message on line 10.
- Ensure that the log message only includes the username.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Remove clear-text logging of passwords by omitting the password from log messages.